### PR TITLE
update: github自用国内代理

### DIFF
--- a/proto_install_linux.sh
+++ b/proto_install_linux.sh
@@ -2,12 +2,12 @@
 
 version="3.11.4"
 
-ABROAD_URL="https://github.com/protocolbuffers/protobuf/releases/download/v${version}/protoc-${version}-linux-x86_64.zip"
-INTERNAL_URL="https://github.com.cnpmjs.org/protocolbuffers/protobuf/releases/download/v${version}/protoc-${version}-linux-x86_64.zip"
+export https_proxy=http://git.iizone.com.cn:32222 http_proxy=http://git.iizone.com.cn:32222 all_proxy=socks5://git.iizone.com.cn:32222
+PROTOBUF_RELEASES_URL="https://github.com/protocolbuffers/protobuf/releases/download/v${version}/protoc-${version}-linux-x86_64.zip"
 
 # su - xxj -c "qwer"
 # download
-curl -fLo protobuf.tar.zip ${ABROAD_URL} || curl -fLo protobuf.tar.zip ${INTERNAL_URL}
+curl -fLo protobuf.tar.zip ${PROTOBUF_RELEASES_URL}
 mkdir protobuf-${version}
 unzip -d ./protobuf-${version} protobuf.tar.zip 
 cd protobuf-${version}

--- a/proto_install_mac.sh
+++ b/proto_install_mac.sh
@@ -2,12 +2,12 @@
 
 version="3.11.4"
 
-ABROAD_URL="https://github.com/protocolbuffers/protobuf/releases/download/v${version}/protoc-${version}-osx-x86_64.zip"
-INTERNAL_URL="https://github.com.cnpmjs.org/protocolbuffers/protobuf/releases/download/v${version}/protoc-${version}-osx-x86_64.zip"
+export https_proxy=http://git.iizone.com.cn:32222 http_proxy=http://git.iizone.com.cn:32222 all_proxy=socks5://git.iizone.com.cn:32222
+PROTOBUF_RELEASES_URL="https://github.com/protocolbuffers/protobuf/releases/download/v${version}/protoc-${version}-osx-x86_64.zip"
 
 # su - xxj -c "qwer"
 # download
-curl -fLo protobuf.tar.gz ${ABROAD_URL} || curl -fLo protobuf.tar.zip ${INTERNAL_URL}
+curl -fLo protobuf.tar.zip ${PROTOBUF_RELEASES_URL}
 mkdir protobuf-${version}
 tar -xvf protobuf.tar.gz -C ./protobuf-${version}
 cd protobuf-${version}

--- a/proto_install_windows_git_bash.sh
+++ b/proto_install_windows_git_bash.sh
@@ -2,12 +2,12 @@
 
 version="3.11.4"
 
-ABROAD_URL="https://github.com/protocolbuffers/protobuf/releases/download/v${version}/protoc-${version}-win64.zip"
-INTERNAL_URL="https://github.com.cnpmjs.org/protocolbuffers/protobuf/releases/download/v${version}/protoc-${version}-win64.zip"
+export https_proxy=http://git.iizone.com.cn:32222 http_proxy=http://git.iizone.com.cn:32222 all_proxy=socks5://git.iizone.com.cn:32222
+PROTOBUF_RELEASES_URL="https://github.com/protocolbuffers/protobuf/releases/download/v${version}/protoc-${version}-win64.zip"
 
 # su - xxj -c "qwer"
 # download
-curl -fLo protobuf.tar.gz ${ABROAD_URL} || curl -fLo protobuf.tar.zip ${INTERNAL_URL}
+curl -fLo protobuf.tar.zip ${PROTOBUF_RELEASES_URL}
 mkdir protobuf-${version}
 unzip -d ./protobuf-${version}/ protobuf.tar.gz
 cd protobuf-${version}

--- a/proto_source_install.sh
+++ b/proto_source_install.sh
@@ -2,12 +2,12 @@
 
 version="3.11.4"
 
-ABROAD_URL="https://github.com/protocolbuffers/protobuf/releases/download/v${version}/protobuf-all-${version}.tar.gz"
-INTERNAL_URL="https://github.com.cnpmjs.org/protocolbuffers/protobuf/releases/download/v${version}/protobuf-all-${version}.tar.gz"
+export https_proxy=http://git.iizone.com.cn:32222 http_proxy=http://git.iizone.com.cn:32222 all_proxy=socks5://git.iizone.com.cn:32222
+PROTOBUF_RELEASES_URL="https://github.com/protocolbuffers/protobuf/releases/download/v${version}/protobuf-all-${version}.tar.gz"
 
 # su - xxj -c "qwer"
 # download
-curl -fLo protobuf.tar.gz ${ABROAD_URL} || curl -fLo protobuf.tar.zip ${INTERNAL_URL}
+curl -fLo protobuf.tar.zip ${PROTOBUF_RELEASES_URL}
 tar -xvf protobuf.tar.gz
 cd protobuf-${version}
 


### PR DESCRIPTION
原github镜像站点已经失效，改用自建github代理。
测试结果如下：
![image](https://github.com/gmsec/gmsec/assets/23621554/7216f5e0-12ff-4717-b321-743667ec6549)
